### PR TITLE
Use build-time information in version function instead of constants

### DIFF
--- a/bin/nanocl/src/version.rs
+++ b/bin/nanocl/src/version.rs
@@ -1,7 +1,7 @@
 pub fn print_version() {
-  const ARCH: &str = "amd64";
-  const VERSION: &str = "0.1.8";
-  const COMMIT_ID: &str = "1243eb28";
+  const ARCH: &str = env!("TARGET_ARCH");
+  const VERSION: &str = env!("CARGO_PKG_VERSION");
+  const COMMIT_ID: &str = env!("GIT_HASH");
 
   println!("Arch: {}", ARCH);
   println!("Version: {}", VERSION);


### PR DESCRIPTION
I am not sure about `TARGET_ARCH` maybe it's better to be used directly as `CARGO_CFG_TARGET_ARCH`.
But whatever...

Take care.