### PR TITLE
[REFACTOR] Nanocld system network now contain correct name

### DIFF
--- a/bin/nanocl/src/commands/cargo.rs
+++ b/bin/nanocl/src/commands/cargo.rs
@@ -125,7 +125,6 @@ async fn exec_cargo_exec(
   options: &CargoExecOpts,
 ) -> Result<(), CliError> {
   let exec: CreateExecOptions<String> = options.to_owned().into();
-  println!("exec: {:?}", exec);
   let mut stream = client
     .exec_cargo(&options.name, exec, args.namespace.to_owned())
     .await?;

--- a/bin/nanocl/src/commands/version.rs
+++ b/bin/nanocl/src/commands/version.rs
@@ -49,7 +49,9 @@ async fn print_latest_version() -> Result<(), CliError> {
 }
 
 async fn get_latest_version() -> Result<Option<String>, CliError> {
-  let tags = github_get_tags().await.unwrap();
+  let tags = github_get_tags().await.map_err(|e| CliError::Custom {
+    msg: format!("Failed to get tags from GitHub: {e}"),
+  })?;
   let last_version = tags.first().map(|tag| tag.name.clone());
 
   Ok(last_version)

--- a/bin/nanocld/src/boot/init.rs
+++ b/bin/nanocld/src/boot/init.rs
@@ -15,7 +15,7 @@ pub async fn init(
     120,
     bollard::API_DEFAULT_VERSION,
   )?;
-  super::system::ensure_network(&docker_api).await?;
+  super::system::ensure_network("system", &docker_api).await?;
   let pool = super::store::ensure(daemon_conf, &docker_api).await?;
   super::system::register_namespace("global", true, &docker_api, &pool).await?;
   super::system::register_namespace("system", false, &docker_api, &pool)

--- a/bin/nanocld/src/boot/store.rs
+++ b/bin/nanocld/src/boot/store.rs
@@ -30,7 +30,7 @@ fn gen_store_host_conf(config: &DaemonConfig) -> HostConfig {
       name: Some(RestartPolicyNameEnum::UNLESS_STOPPED),
       maximum_retry_count: None,
     }),
-    network_mode: Some(String::from("system-nano-internal0")),
+    network_mode: Some(String::from("system")),
     ..Default::default()
   }
 }

--- a/bin/nanocld/src/boot/system.rs
+++ b/bin/nanocld/src/boot/system.rs
@@ -14,14 +14,12 @@ use crate::models::Pool;
 /// It's ensure existance of a network in your system called `nanoclinternal0`
 /// Also registered inside docker as `system-nano-internal0`
 pub(crate) async fn ensure_network(
+  name: &str,
   docker_api: &bollard::Docker,
 ) -> Result<(), DaemonError> {
-  const SYSTEM_NETWORK_KEY: &str = "system-nano-internal0";
-  const SYSTEM_NETWORK: &str = "nanoclinternal0";
-
   // Ensure network existance
   if docker_api
-    .inspect_network(SYSTEM_NETWORK_KEY, None::<InspectNetworkOptions<&str>>)
+    .inspect_network(name, None::<InspectNetworkOptions<&str>>)
     .await
     .is_ok()
   {
@@ -30,10 +28,10 @@ pub(crate) async fn ensure_network(
   let mut options: HashMap<String, String> = HashMap::new();
   options.insert(
     String::from("com.docker.network.bridge.name"),
-    SYSTEM_NETWORK.to_owned(),
+    format!("nanocl.{name}"),
   );
   let config = CreateNetworkOptions {
-    name: SYSTEM_NETWORK_KEY.to_owned(),
+    name: name.to_owned(),
     driver: String::from("bridge"),
     options,
     ..Default::default()

--- a/bin/nanocld/src/boot/system.rs
+++ b/bin/nanocld/src/boot/system.rs
@@ -11,8 +11,9 @@ use crate::error::DaemonError;
 use crate::models::Pool;
 
 /// Ensure existance of the system network that controllers will use.
-/// It's ensure existance of a network in your system called `nanoclinternal0`
-/// Also registered inside docker as `system-nano-internal0`
+/// It's ensure existance of a network in your system called `nanocl.system`
+/// Also registered inside docker as `system` since it's the name of the namespace.
+/// This network is created to be sure a store is running inside.
 pub(crate) async fn ensure_network(
   name: &str,
   docker_api: &bollard::Docker,

--- a/bin/nanocld/src/utils/namespace.rs
+++ b/bin/nanocld/src/utils/namespace.rs
@@ -69,15 +69,9 @@ pub async fn create(
       status: StatusCode::CONFLICT,
     });
   }
-  let mut options: HashMap<String, String> = HashMap::new();
-  options.insert(
-    String::from("com.docker.network.bridge.name"),
-    format!("nanocl.{}", &namespace.name),
-  );
   let config = CreateNetworkOptions {
     name: namespace.name.to_owned(),
     driver: String::from("bridge"),
-    options,
     ..Default::default()
   };
   docker_api.create_network(config).await?;

--- a/bin/nanocld/src/utils/store.rs
+++ b/bin/nanocld/src/utils/store.rs
@@ -112,7 +112,7 @@ pub async fn get_store_ip_addr(
       status: StatusCode::INTERNAL_SERVER_ERROR,
     })?;
   let ip_address = networks
-    .get("system-nano-internal0")
+    .get("system")
     .ok_or(HttpResponseError {
       msg: String::from("unable to get store network nanocl"),
       status: StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the name of the system network to just system.
And updated the name show with ipaddr to nanocl.{namespace} when creating namespace.

**- How to verify it**
Run the tests
```sh
cargo make cov
```
