### PR TITLE
[FEATURE] Nanocl cargo create with env and volume options

### DIFF
--- a/bin/nanocl/src/commands/cargo.rs
+++ b/bin/nanocl/src/commands/cargo.rs
@@ -32,14 +32,7 @@ async fn exec_cargo_create(
   args: &CargoArgs,
   options: &CargoCreateOpts,
 ) -> Result<(), CliError> {
-  let cargo = CargoConfigPartial {
-    name: options.name.to_owned(),
-    container: bollard::container::Config {
-      image: Some(options.image.to_owned()),
-      ..Default::default()
-    },
-    ..Default::default()
-  };
+  let cargo = options.to_owned().into();
   let item = client
     .create_cargo(&cargo, args.namespace.to_owned())
     .await?;
@@ -125,7 +118,6 @@ async fn exec_cargo_exec(
   options: &CargoExecOpts,
 ) -> Result<(), CliError> {
   let exec: CreateExecOptions<String> = options.to_owned().into();
-  println!("exec: {:?}", exec);
   let mut stream = client
     .exec_cargo(&options.name, exec, args.namespace.to_owned())
     .await?;

--- a/bin/nanocl/src/models/cargo.rs
+++ b/bin/nanocl/src/models/cargo.rs
@@ -4,7 +4,9 @@ use clap::{Parser, Subcommand};
 
 use nanocl_models::{
   cargo::CargoSummary,
-  cargo_config::{CargoConfigPatch, ContainerConfig},
+  cargo_config::{
+    CargoConfigPatch, ContainerConfig, CargoConfigPartial, ContainerHostConfig,
+  },
 };
 
 use super::cargo_image::CargoImageOpts;
@@ -27,8 +29,32 @@ pub struct CargoCreateOpts {
   #[clap(long = "net")]
   pub network: Option<String>,
   /// Volumes of the cargo
-  #[clap(short)]
+  #[clap(short, long = "volume")]
   pub volumes: Option<Vec<String>>,
+  /// Environment variables of the cargo
+  #[clap(short, long = "env")]
+  pub(crate) env: Option<Vec<String>>,
+}
+
+impl From<CargoCreateOpts> for CargoConfigPartial {
+  fn from(val: CargoCreateOpts) -> Self {
+    Self {
+      name: val.name,
+      container: ContainerConfig {
+        image: Some(val.image),
+        // network: val.network,
+        // volumes: val.volumes,
+        env: val.env,
+        host_config: Some(ContainerHostConfig {
+          network_mode: val.network,
+          binds: val.volumes,
+          ..Default::default()
+        }),
+        ..Default::default()
+      },
+      ..Default::default()
+    }
+  }
 }
 
 /// Start Cargo options

--- a/bin/nanocl/src/models/cargo.rs
+++ b/bin/nanocl/src/models/cargo.rs
@@ -25,6 +25,9 @@ pub struct CargoCreateOpts {
   pub name: String,
   /// Image of the cargo
   pub image: String,
+  /// Network of the cargo this is automatically set to the namespace network
+  #[clap(long = "net")]
+  pub network: Option<String>,
   /// Volumes of the cargo
   #[clap(short, long = "volume")]
   pub volumes: Option<Vec<String>>,
@@ -43,6 +46,7 @@ impl From<CargoCreateOpts> for CargoConfigPartial {
         // volumes: val.volumes,
         env: val.env,
         host_config: Some(ContainerHostConfig {
+          network_mode: val.network,
           binds: val.volumes,
           ..Default::default()
         }),

--- a/bin/nanocl/src/models/cargo.rs
+++ b/bin/nanocl/src/models/cargo.rs
@@ -25,9 +25,6 @@ pub struct CargoCreateOpts {
   pub name: String,
   /// Image of the cargo
   pub image: String,
-  /// Network of the cargo
-  #[clap(long = "net")]
-  pub network: Option<String>,
   /// Volumes of the cargo
   #[clap(short, long = "volume")]
   pub volumes: Option<Vec<String>>,
@@ -46,7 +43,6 @@ impl From<CargoCreateOpts> for CargoConfigPartial {
         // volumes: val.volumes,
         env: val.env,
         host_config: Some(ContainerHostConfig {
-          network_mode: val.network,
           binds: val.volumes,
           ..Default::default()
         }),

--- a/bin/nanocl/src/models/cargo.rs
+++ b/bin/nanocl/src/models/cargo.rs
@@ -19,7 +19,7 @@ pub struct CargoDeleteOpts {
 }
 
 /// Create cargo options
-#[derive(Debug, Parser)]
+#[derive(Debug, Clone, Parser)]
 pub struct CargoCreateOpts {
   /// Name of the cargo
   pub name: String,

--- a/crates/nanocl_models/src/cargo_config.rs
+++ b/crates/nanocl_models/src/cargo_config.rs
@@ -2,6 +2,7 @@
 use serde::{Serialize, Deserialize};
 
 pub type ContainerConfig<T> = bollard::container::Config<T>;
+pub type ContainerHostConfig = bollard::models::HostConfig;
 
 /// Auto is used to automatically define that the number of replicas in the cluster
 /// Number is used to manually set the number of replicas


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added more options for the CLI to handle environnements and volumes at creation

**- How I did it**
I implemented the trait `From` to convert `CargoCreateOpts` into `CargoConfigPartial`

**- How to verify it**
Run tests
