### PR TITLE
chore: upgrade tabled to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
- "tabled",
+ "tabled 0.10.0",
+ "tabled 0.12.0",
  "termios",
  "tokio",
  "tokio-util",
@@ -2433,6 +2434,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdfe703c51ddc52887ad78fc69cd2ea78d895ffcd6e955c9d03566db8ab5bb1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
  "bitflags",
  "errno",
@@ -3107,8 +3119,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c3ee73732ffceaea7b8f6b719ce3bb17f253fa27461ffeaf568ebd0cdb4b85"
 dependencies = [
- "papergrid",
- "tabled_derive",
+ "papergrid 0.7.1",
+ "tabled_derive 0.5.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1a2e56bbf7bfdd08aaa7592157a742205459eff774b73bc01809ae2d99dc2a"
+dependencies = [
+ "papergrid 0.9.0",
+ "tabled_derive 0.6.0",
  "unicode-width",
 ]
 
@@ -3117,6 +3140,19 @@ name = "tabled_derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca1b4eaceb4f2755df858b88d9b9315b7ccfd1ffd0d7a48a52602301f01a57"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3220,9 +3256,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3232,14 +3268,14 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.4.9",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3266,11 +3302,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/bin/nanocl/Cargo.toml
+++ b/bin/nanocl/Cargo.toml
@@ -37,7 +37,7 @@ nanocld_client = { version = "0.5.0", features = ["tokio"] }
 bollard-next = { version = "0.14.9" }
 futures = "0.3"
 serde_yaml = "0.9"
-tabled = "0.10.0"
+tabled = "0.12.0"
 indicatif = "0.17.3"
 serde_json = "1.0.89"
 ntex = { version = "0.6.6", features = ["rustls", "tokio"] }

--- a/bin/nanocl/src/utils/print.rs
+++ b/bin/nanocl/src/utils/print.rs
@@ -1,7 +1,6 @@
-use tabled::{
-  object::{Segment, Rows},
-  Padding, Alignment, Table, Style, Modify,
-};
+use tabled::Table;
+use tabled::settings::object::{Rows, Segment};
+use tabled::settings::{Style, Modify, Padding, Alignment};
 
 use nanocl_utils::io_error::{IoResult, FromIo};
 
@@ -16,7 +15,6 @@ where
         .with(Padding::new(0, 4, 0, 0))
         .with(Alignment::left()),
     )
-    .with(Modify::new(Rows::first()).with(str::to_uppercase))
     .to_string();
   println!("{table}");
 }

--- a/bin/nanocl/src/utils/print.rs
+++ b/bin/nanocl/src/utils/print.rs
@@ -1,5 +1,5 @@
 use tabled::Table;
-use tabled::settings::object::{Rows, Segment};
+use tabled::settings::object::Segment;
 use tabled::settings::{Style, Modify, Padding, Alignment};
 
 use nanocl_utils::io_error::{IoResult, FromIo};


### PR DESCRIPTION
closes https://github.com/nxthat/nanocl/issues/226