### PR TITLE
bugfix: change nanocl to use cargo in test

### DIFF
--- a/bin/ncdproxy/src/utils.rs
+++ b/bin/ncdproxy/src/utils.rs
@@ -547,8 +547,8 @@ pub(crate) mod tests {
   pub async fn exec_nanocl(arg: &str) -> std::io::Result<Output> {
     let arg = arg.to_owned();
     ntex::web::block(move || {
-      let mut cmd = std::process::Command::new("nanocl");
-      let mut args = vec![];
+      let mut cmd = std::process::Command::new("cargo");
+      let mut args = vec!["make", "run-cli"];
       args.extend(arg.split(' ').collect::<Vec<&str>>());
       cmd.args(&args);
       let output = cmd.output()?;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed the CLI command from `nanocl ...` to use `cargo ...` to accommodate for `nanocl` not being set in `PATH`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Changed the CLI command from `nanocl ...` to use `cargo ...`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/nxthat/nanocl/assets/33705740/d9294d77-578d-46e6-87e7-2d27c4d7d9b4)