### PR TITLE
feat(nanocl:cargo): add missing options

### DIFF
--- a/bin/nanocl/src/main.rs
+++ b/bin/nanocl/src/main.rs
@@ -320,7 +320,7 @@ mod tests {
   /// Test cargo exec command
   #[ntex::test]
   async fn cargo_exec() {
-    let args = Cli::parse_from([
+    let mut args = Cli::parse_from([
       "nanocl",
       "cargo",
       "--namespace",
@@ -330,6 +330,60 @@ mod tests {
       "--",
       "echo",
       "hello",
+    ]);
+    assert!(execute_arg(&args).await.is_ok());
+
+    args = Cli::parse_from([
+      "nanocl",
+      "cargo",
+      "--namespace",
+      "system",
+      "exec",
+      "nstore",
+      "-e",
+      "A=test",
+      "--",
+      "env",
+    ]);
+    assert!(execute_arg(&args).await.is_ok());
+
+    args = Cli::parse_from([
+      "nanocl",
+      "cargo",
+      "--namespace",
+      "system",
+      "exec",
+      "nstore",
+      "--privileged",
+      "--",
+      "whoami",
+    ]);
+    assert!(execute_arg(&args).await.is_ok());
+
+    args = Cli::parse_from([
+      "nanocl",
+      "cargo",
+      "--namespace",
+      "system",
+      "exec",
+      "nstore",
+      "-t",
+      "--",
+      "ls",
+    ]);
+    assert!(execute_arg(&args).await.is_ok());
+
+    args = Cli::parse_from([
+      "nanocl",
+      "cargo",
+      "--namespace",
+      "system",
+      "exec",
+      "nstore",
+      "-u",
+      "0",
+      "--",
+      "whoami",
     ]);
     assert!(execute_arg(&args).await.is_ok());
   }

--- a/bin/nanocl/src/models/cargo.rs
+++ b/bin/nanocl/src/models/cargo.rs
@@ -196,11 +196,29 @@ impl From<CargoPatchOpts> for CargoConfigUpdate {
 ///
 #[derive(Debug, Clone, Parser)]
 pub struct CargoExecOpts {
+  /// Allocate a pseudo-TTY.
+  #[clap(short = 't', long = "tty")]
+  pub tty: bool,
   /// Name of cargo to execute command
   pub name: String,
   /// Command to execute
   #[clap(last = true, raw = true)]
   pub command: Vec<String>,
+  /// Override the key sequence for detaching a container.
+  #[clap(long)]
+  pub detach_keys: Option<String>,
+  /// Set environment variables
+  #[clap(short)]
+  pub env: Option<Vec<String>>,
+  /// Give extended privileges to the command
+  #[clap(long)]
+  pub privileged: bool,
+  /// Username or UID (format: "<name|uid>[:<group|gid>]")
+  #[clap(short)]
+  pub user: Option<String>,
+  /// Working directory inside the container
+  #[clap(short, long = "workdir")]
+  pub working_dir: Option<String>,
 }
 
 /// Convert CargoExecOpts to CreateExecOptions
@@ -208,6 +226,12 @@ impl From<CargoExecOpts> for CreateExecOptions {
   fn from(val: CargoExecOpts) -> Self {
     CreateExecOptions {
       cmd: Some(val.command),
+      tty: Some(val.tty),
+      detach_keys: val.detach_keys,
+      env: val.env,
+      privileged: Some(val.privileged),
+      user: val.user,
+      working_dir: val.working_dir,
       attach_stderr: Some(true),
       attach_stdout: Some(true),
       ..Default::default()

--- a/bin/nanocld/src/utils/cargo.rs
+++ b/bin/nanocld/src/utils/cargo.rs
@@ -869,7 +869,13 @@ pub async fn exec_command(
   let result = state.docker_api.create_exec(&name, args.to_owned()).await?;
   let res = state
     .docker_api
-    .start_exec(&result.id, Some(StartExecOptions::default()))
+    .start_exec(
+      &result.id,
+      Some(StartExecOptions {
+        tty: args.tty.unwrap_or_default(),
+        ..Default::default()
+      }),
+    )
     .await?;
   match res {
     StartExecResults::Detached => Ok(web::HttpResponse::Ok().finish()),

--- a/examples/cargo_example.yml
+++ b/examples/cargo_example.yml
@@ -8,4 +8,4 @@ Namespace: cargo-example
 Cargoes:
   - Name: cargo-example
     Container:
-      Image: nexthat/nanocl-get-started:latest
+      Image: alpine:latest


### PR DESCRIPTION
**- What I did**
Adding following options to cargo exec :
tty
detach_keys
env
privileged
user
working_dir

**- How I did it**
Adding it to cargo exec opts

**- How to verify it**
Run cargo exec with following options

**- Description for the changelog**
Cargo exec options tty detach_keys env privileged user working_dir
