### PR TITLE
build(dev): use directly ndns and nproxy docker for dev compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,9 @@ services:
 
   nproxy:
     container_name: nproxy.system.c
-    image: nproxy:dev
+    build:
+      context: .
+      dockerfile: ./bin/nproxy/Dockerfile
     tty: true
     network_mode: host
     profiles:
@@ -114,7 +116,9 @@ services:
 
   ndns:
     container_name: ndns.system.c
-    image: ndns:dev
+    build:
+      context: .
+      dockerfile: ./bin/ndns/Dockerfile
     tty: true
     profiles:
       - dns


### PR DESCRIPTION
**- What I did**
Avoid an error when dev images for ndns nproxy doesn't exist
**- How I did it**
Using build field in compose file
**- How to verify it**
run docker compose --profile proxy --profile dns up without having dev images
