### PR TITLE
Process Stats command implementation in nanocl

### DIFF
--- a/bin/nanocl/changelog.md
+++ b/bin/nanocl/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [untagged] - yyyy-mm-dd 
+
+### Added
+- `nanocl stats` to get stats of multiple processes by name [n0tank3sh](https://github.com/n0tank3sh) 
+
 ## [0.16.2] - 2024-11-24
 
 ### Changed

--- a/bin/nanocl/src/commands/mod.rs
+++ b/bin/nanocl/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod process;
 mod resource;
 mod secret;
 mod state;
+mod stats;
 #[cfg(not(target_os = "windows"))]
 mod uninstall;
 mod version;
@@ -37,6 +38,7 @@ pub use process::{exec_process, inspect_process, logs_process};
 pub use resource::exec_resource;
 pub use secret::exec_secret;
 pub use state::exec_state;
+pub use stats::exec_stats;
 #[cfg(not(target_os = "windows"))]
 pub use uninstall::exec_uninstall;
 pub use version::exec_version;

--- a/bin/nanocl/src/commands/stats.rs
+++ b/bin/nanocl/src/commands/stats.rs
@@ -1,0 +1,43 @@
+use crate::{
+  config::CliConfig,
+  models::{ProcessStatsRow, StatsOpts},
+  utils,
+};
+use futures::{channel::mpsc, StreamExt};
+use nanocl_error::io::IoResult;
+use std::collections::HashMap;
+
+pub async fn exec_stats(
+  cli_config: &CliConfig,
+  stats_arg: &StatsOpts,
+) -> IoResult<()> {
+  let client = cli_config.client.clone();
+  let terminal = dialoguer::console::Term::stdout();
+  let (tx_stat, mut recv_stat) = mpsc::unbounded();
+  {
+    let proc_list = stats_arg.names.clone();
+    let client = client.clone();
+    ntex::rt::spawn(async move {
+      let fut = proc_list.iter().map(|x| async {
+        let Ok(mut stream) = client.stats_process_by_name(x).await else {
+          return;
+        };
+        while let Some(stat_res) = stream.next().await {
+          if let Ok(stat) = stat_res {
+            let _ = tx_stat.unbounded_send(stat);
+          }
+        }
+      });
+      futures::future::join_all(fut).await;
+    });
+  }
+  let mut proc_map = HashMap::new();
+  while let Some(stat) = recv_stat.next().await {
+    proc_map.insert(stat.name.clone(), stat.clone());
+    terminal.clear_screen()?;
+    utils::print::print_table(
+      proc_map.values().map(|x| ProcessStatsRow::from(x.clone())),
+    );
+  }
+  Ok(())
+}

--- a/bin/nanocl/src/main.rs
+++ b/bin/nanocl/src/main.rs
@@ -820,7 +820,9 @@ mod tests {
 
   #[ntex::test]
   async fn stats() {
-    assert_cli_ok!("stats", "nstore.system.c");
+    ntex::rt::spawn(async {
+      assert_cli_ok!("stats", "nstore.system.c");
+    });
   }
 
   #[ntex::test]

--- a/bin/nanocl/src/main.rs
+++ b/bin/nanocl/src/main.rs
@@ -92,6 +92,7 @@ async fn execute_arg(cli_args: &Cli) -> IoResult<()> {
     Command::Secret(args) => commands::exec_secret(&cli_conf, args).await,
     Command::Event(args) => commands::exec_event(&cli_conf, args).await,
     Command::State(args) => commands::exec_state(&cli_conf, args).await,
+    Command::Stats(args) => commands::exec_stats(&cli_conf, args).await,
     Command::Version => commands::exec_version(&cli_conf).await,
     Command::Vm(args) => commands::exec_vm(&cli_conf, args).await,
     Command::Logs(args) => commands::logs_process(&cli_conf, args).await,
@@ -815,6 +816,11 @@ mod tests {
     assert_cli_ok!("vm", "run", "test-cli-vm", "test-cli-image");
     assert_cli_ok!("vm", "rm", "-y", "test-cli-vm");
     assert_cli_ok!("vm", "image", "rm", "-y", "test-cli-image");
+  }
+
+  #[ntex::test]
+  async fn stats() {
+    assert_cli_ok!("stats", "nstore.system.c");
   }
 
   #[ntex::test]

--- a/bin/nanocl/src/models/mod.rs
+++ b/bin/nanocl/src/models/mod.rs
@@ -16,6 +16,7 @@ mod process;
 mod resource;
 mod secret;
 mod state;
+mod stats;
 mod uninstall;
 mod version;
 mod vm;
@@ -35,6 +36,7 @@ pub use process::*;
 pub use resource::*;
 pub use secret::*;
 pub use state::*;
+pub use stats::*;
 pub use uninstall::*;
 pub use vm::*;
 pub use vm_image::*;
@@ -129,6 +131,8 @@ pub enum Command {
   Uninstall(UninstallOpts),
   /// Backup the current state
   Backup(BackupOpts),
+  /// Stats of the process
+  Stats(StatsOpts),
   // TODO: shell completion
   // Completion {
   //   /// Shell to generate completion for

--- a/bin/nanocl/src/models/stats.rs
+++ b/bin/nanocl/src/models/stats.rs
@@ -1,0 +1,6 @@
+use clap::Parser;
+
+#[derive(Default, Parser)]
+pub struct StatsOpts {
+  pub names: Vec<String>,
+}

--- a/bin/nanocld/changelog.md
+++ b/bin/nanocld/changelog.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Endpoint `GET /process/{name}/stats` to get process stats by it's name by [n0tank3sh](https://github.com/n0tank3sh)
 
-### Fixed
-
-- Fixed vulnerability that allowed deletion of critical namespaces (global and system) by [n0tank3sh](https://github.com/n0tank3sh)
-
 ## [0.16.3] - 2025-03-14
 
 ### Fixed

--- a/bin/nanocld/changelog.md
+++ b/bin/nanocld/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [untagged] - yyyy-mm-dd
+
+### Added
+
+- Endpoint `GET /process/{name}/stats` to get process stats by it's name by [n0tank3sh](https://github.com/n0tank3sh)
+
 ## [0.16.2] - 2024-11-24
 
 ### Changed

--- a/bin/nanocld/src/services/openapi.rs
+++ b/bin/nanocld/src/services/openapi.rs
@@ -136,6 +136,7 @@ impl Modify for VersionModifier {
     process::count_processes,
     process::inspect_process,
     process::start_process_by_pk,
+    process::process_stats_by_name,
     // Event
     event::list_event,
     event::watch_event,

--- a/bin/nanocld/src/services/process/mod.rs
+++ b/bin/nanocld/src/services/process/mod.rs
@@ -74,11 +74,17 @@ mod tests {
     test_status_code!(res.status(), http::StatusCode::OK, "basic cargo stats");
   }
   #[ntex::test]
-  async fn test_process_stats_by_name() { 
+  async fn test_process_stats_by_name() {
     let system = gen_default_test_system().await;
     let client = system.client;
-    let res =  client.send_get("/process/nstore.system.c/stats", None::<String>).await;
-    test_status_code!(res.status(), http::StatusCode::OK, "process by name stats");
+    let res = client
+      .send_get("/process/nstore.system.c/stats", None::<String>)
+      .await;
+    test_status_code!(
+      res.status(),
+      http::StatusCode::OK,
+      "process by name stats"
+    );
   }
   #[ntex::test]
   async fn list_by() {

--- a/bin/nanocld/src/services/process/mod.rs
+++ b/bin/nanocld/src/services/process/mod.rs
@@ -34,6 +34,7 @@ pub fn ntex_config(config: &mut web::ServiceConfig) {
   config.service(wait_processes);
   config.service(stats_processes);
   config.service(count_processes);
+  config.service(process_stats_by_name);
 }
 
 #[cfg(test)]
@@ -72,7 +73,13 @@ mod tests {
       .await;
     test_status_code!(res.status(), http::StatusCode::OK, "basic cargo stats");
   }
-
+  #[ntex::test]
+  async fn test_process_stats_by_name() { 
+    let system = gen_default_test_system().await;
+    let client = system.client;
+    let res =  client.send_get("/process/nstore.system.c/stats", None::<String>).await;
+    test_status_code!(res.status(), http::StatusCode::OK, "process by name stats");
+  }
   #[ntex::test]
   async fn list_by() {
     let system = gen_default_test_system().await;

--- a/bin/nanocld/src/services/process/stats.rs
+++ b/bin/nanocld/src/services/process/stats.rs
@@ -70,7 +70,9 @@ pub async fn stats_processes(
   tag = "Processes",
   path = "/process/{name}/stats",
   params(
-    ("name" = String, Path, description = "Name of the process", example = "deploy-example")
+    ("name" = String, Path, description = "Name of the process", example = "deploy-example"),
+    ("stream" = Option<bool>, Query, description = "Return a stream of stats"),
+    ("one_shot" = Option<bool>, Query, description = "Return stats only once"),
   ),
   responses(
     (status = 200, description = "Process stats", content_type = "application/vdn.nanocl.raw-stream", body = ProcessStats),
@@ -81,13 +83,15 @@ pub async fn stats_processes(
 pub async fn process_stats_by_name(
   state: web::types::State<SystemState>,
   path: web::types::Path<(String, String)>,
+  qs: web::types::Query<ProcessStatsQuery>,
 ) -> HttpResult<web::HttpResponse> {
   let (_, process) = path.into_inner();
+  let opts: StatsOptions = qs.clone().into();
   let stream =
     state
       .inner
       .docker_api
-      .stats(&process, None)
+      .stats(&process, Some(opts))
       .map(move |elem| match elem {
         Ok(stats) => Ok(ProcessStats {
           name: process.clone(),

--- a/bin/nanocld/src/services/process/stats.rs
+++ b/bin/nanocld/src/services/process/stats.rs
@@ -63,3 +63,43 @@ pub async fn stats_processes(
       ),
   )
 }
+
+/// Get stats of a process by it's key name
+#[cfg_attr(feature = "dev", utoipa::path(
+  get,
+  tag = "Processes",
+  path = "/process/{name}/stats",
+  params(
+    ("name" = String, Path, description = "Name of the process", example = "deploy-example")
+  ),
+  responses(
+    (status = 200, description = "Process stats", content_type = "application/vdn.nanocl.raw-stream", body = ProcessStats),
+    (status = 404, description = "Process does not exist", body = crate::services::openapi::ApiError),
+  )
+))]
+#[web::get("/process/{name}/stats")]
+pub async fn process_stats_by_name(
+  state: web::types::State<SystemState>,
+  path: web::types::Path<(String, String)>,
+) -> HttpResult<web::HttpResponse> {
+  let (_, process) = path.into_inner();
+  let stream =
+    state
+      .inner
+      .docker_api
+      .stats(&process, None)
+      .map(move |elem| match elem {
+        Ok(stats) => Ok(ProcessStats {
+          name: process.clone(),
+          stats,
+        }),
+        Err(err) => Err(err),
+      });
+  Ok(
+    web::HttpResponse::Ok()
+      .content_type("application/vdn.nanocl.raw-stream")
+      .streaming(
+        utils::stream::transform_stream::<ProcessStats, ProcessStats>(stream),
+      ),
+  )
+}

--- a/crates/nanocld_client/src/process.rs
+++ b/crates/nanocld_client/src/process.rs
@@ -215,6 +215,14 @@ impl NanocldClient {
   }
   /// The stats are streamed as a [Receiver](Receiver) of [stats](Stats)
   /// It get the stats by key name(returned by nanocl ps) instead of name and kind
+  /// ## Example
+  ///
+  /// ```no_run, ignore
+  /// use nanocld_client::NanocldClient;
+  /// let client = NanocldClient::connect_to("http://localhost:8585", None);
+  /// let stats = client.stats_process_by_name("nstore.system.c");
+  /// ```
+  ///
   pub async fn stats_process_by_name(
     &self,
     name: &str,
@@ -275,13 +283,16 @@ mod tests {
   }
 
   #[ntex::test]
-  async fn process_stats_by_name() { 
-    let client = NanocldClient::connect_to(&ConnectOpts{
-        url: "http://nanocl.internal:8585".into(),
-        ..Default::default()
-        })
-        .expect("Failed to create a nanocl client");
-    let mut rx = client.stats_process_by_name("nstore.system.c").await.unwrap();
+  async fn process_stats_by_name() {
+    let client = NanocldClient::connect_to(&ConnectOpts {
+      url: "http://nanocl.internal:8585".into(),
+      ..Default::default()
+    })
+    .expect("Failed to create a nanocl client");
+    let mut rx = client
+      .stats_process_by_name("nstore.system.c")
+      .await
+      .unwrap();
     let _out = rx.next().await.unwrap().unwrap();
   }
 

--- a/crates/nanocld_client/src/process.rs
+++ b/crates/nanocld_client/src/process.rs
@@ -213,6 +213,18 @@ impl NanocldClient {
       .await?;
     Ok(Self::res_stream(res).await)
   }
+  /// The stats are streamed as a [Receiver](Receiver) of [stats](Stats)
+  /// It get the stats by key name(returned by nanocl ps) instead of name and kind
+  pub async fn stats_process_by_name(
+    &self,
+    name: &str,
+  ) -> HttpClientResult<Receiver<HttpResult<ProcessStats>>> {
+    let query: Option<&ProcessStatsQuery> = None;
+    let res = self
+      .send_get(&format!("/process/{name}/stats"), query)
+      .await?;
+    Ok(Self::res_stream(res).await)
+  }
 
   /// Inspect a process by it's name
   ///
@@ -259,6 +271,17 @@ mod tests {
       )
       .await
       .unwrap();
+    let _out = rx.next().await.unwrap().unwrap();
+  }
+
+  #[ntex::test]
+  async fn process_stats_by_name() { 
+    let client = NanocldClient::connect_to(&ConnectOpts{
+        url: "http://nanocl.internal:8585".into(),
+        ..Default::default()
+        })
+        .expect("Failed to create a nanocl client");
+    let mut rx = client.stats_process_by_name("nstore.system.c").await.unwrap();
     let _out = rx.next().await.unwrap().unwrap();
   }
 


### PR DESCRIPTION
fixes: #1144 


**- What I did**
I implemented the processstats. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
It's implements nanocl stats in the client. 

**- A picture of a cute animal (not mandatory but encouraged)**

![doggo](https://github.com/user-attachments/assets/b050050c-e740-45ce-b954-cc7d659b6539)
