### PR TITLE
docs: fix star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ You may use either license at your discretion.
  </span>
 </blockquote>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=next-hat/nanocl&type=Date)](https://star-history.com/#next-hat/nanocl&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=next-hat/nanocl&type=Date)](https://star-history.dera.page/#next-hat/nanocl&type=date)
 
 [contributing_guide]: ./CONTRIBUTING.md
 [next_hat]: https://next-hat.com


### PR DESCRIPTION
The star history chart image in the README is broken because the underlying service relies on the GitHub stargazer API, which now has usage restrictions. This change updates the chart to use an alternative that works without an API token, so the chart renders correctly again.